### PR TITLE
Update the samtools command-line option to match the variable.

### DIFF
--- a/fpfilter.pl
+++ b/fpfilter.pl
@@ -50,7 +50,7 @@ $opt_result = GetOptions(
     'bam-index=s' => \$bam_index,
     'sample=s' => \$sample,
     'bam-readcount=s' => \$bam_readcount_path,
-    'bam-readcount=s' => \$samtools_path,
+    'samtools=s' => \$samtools_path,
     'reference=s' => \$ref_fasta,
     'output=s'   => \$output_file,
     'min-read-pos=f' => \$min_read_pos,


### PR DESCRIPTION
Their was a typo in the GetOptions that defined the bam-readcount input twice, once for `$bam_readcount_path` and again for the `$samtools_path`.  Added a `samtools` input for the `$samtools_path` variable.
